### PR TITLE
Adding the ability to clone a widget

### DIFF
--- a/components/class-go-copylayout.php
+++ b/components/class-go-copylayout.php
@@ -2,12 +2,15 @@
 
 class GO_CopyLayout
 {
+	public $script_version = 1;
+
 	/**
 	 * constructor
 	 */
 	public function __construct()
 	{
 		add_action( 'init', array( $this, 'init' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 	}//end __construct
 
 	/**
@@ -22,6 +25,38 @@ class GO_CopyLayout
 
 		add_action('admin_menu', array( $this, 'admin_menu' ) );
 	}//end init
+
+	/**
+	 * Hook into the wp_enqueue_scripts action to inject JS
+	 */
+	public function admin_enqueue_scripts()
+	{
+		global $pagenow;
+
+		if ( 'widgets.php' != $pagenow )
+		{
+			return;
+		}//end if
+
+		wp_register_script(
+			'go-copylayout',
+			plugins_url( 'js/go-copylayout.js', __FILE__ ),
+			array( 'jquery' ),
+			$this->script_version,
+			TRUE
+		);
+
+		wp_enqueue_script( 'go-copylayout' );
+
+		wp_register_style(
+			'go-copylayout',
+			plugins_url( 'css/go-copylayout.css', __FILE__ ),
+			array(),
+			$this->script_version
+		);
+
+		wp_enqueue_style( 'go-copylayout' );
+	}//end admin_enqueue_scripts
 
 	/**
 	 * Add the "Copy Layout" link to the admin sidebar.

--- a/components/css/go-copylayout.css
+++ b/components/css/go-copylayout.css
@@ -1,0 +1,18 @@
+a.clone-widget {
+	color: #b6b6b6;
+	display: block;
+	float: left;
+	font-size: 120%;
+	font-weight: bold;
+	line-height: 26px;
+	margin-left: -5px;
+	text-decoration: none;
+}
+
+a.clone-widget:hover {
+	color: #555;
+}
+
+.widget-title h4 {
+	margin-right: 2.5em;
+}

--- a/components/js/go-copylayout.js
+++ b/components/js/go-copylayout.js
@@ -1,0 +1,109 @@
+/**
+* This javascript is based on the code by Ben Doherty @ Oomph, Inc. (http://thinkoomph.com/ben-doherty) and
+* is licensed under GPLv2 or later
+*
+* 	Copyright © 2012 Oomph, Inc. <http://oomphinc.com>
+*
+* 	This program is free software: you can redistribute it and/or modify
+* 	it under the terms of the GNU General Public License as published by
+* 	the Free Software Foundation, either version 3 of the License, or
+* 	(at your option) any later version.
+*
+* 	This program is distributed in the hope that it will be useful,
+* 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+* 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* 	GNU General Public License for more details.
+*
+* 	You should have received a copy of the GNU General Public License
+* 	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+var go_copylayout = {};
+
+(function( $ ) {
+	"use strict";
+
+	go_copylayout.init = function() {
+		go_copylayout.$active_widgets = $('#widgets-right');
+
+		go_copylayout.$active_widgets.on( 'click', '.clone-widget', go_copylayout.clone );
+
+		go_copylayout.bind();
+	};
+
+	go_copylayout.bind = function() {
+		go_copylayout.$active_widgets.off( 'DOMSubtreeModified', go_copylayout.bind );
+		$('.widgets-sortables .widget-title-action:not(.go-copylayout-cloneable)')
+			.prepend('<a href="javascript:void(0);" class="clone-widget" title="Clone this Widget">+</a>')
+			.addClass('go-copylayout-cloneable');
+		go_copylayout.$active_widgets.on( 'DOMSubtreeModified', go_copylayout.bind );
+	};
+
+	go_copylayout.clone = function( e ) {
+		e.stopPropagation();
+		e.preventDefault();
+
+		var $original = $(this).closest('.widget');
+		var $title      = $original.find('.widget-title h4').clone();
+
+		if ( ! confirm( 'Are you sure you wish to clone this "' + $title.get(0).childNodes[0].nodeValue + '" widget?' ) ) {
+			return;
+		}//end if
+
+		var $new      = $original.clone();
+
+		var id_base      = $new.find('input[name = "id_base"]').val();
+		var number       = $new.find('input[name = "widget_number"]').val();
+		var multi_number = $new.find('input[name = "multi_number"]').val();
+
+		var highest      = 0;
+
+		$('input.widget-id[value|="' + id_base + '"]').each( function() {
+			var match = this.value.match( /-(\d+)$/ );
+
+			if ( match ) {
+				var widget_id = parseInt( match[1], 10 );
+
+				highest = widget_id > highest ? widget_id : highest;
+			}//end if
+		});
+
+		var new_number = highest + 1;
+
+		$new.find('.widget-content').find('input,select,textarea').each(function() {
+			if ( $(this).attr('name') ) {
+				$(this).attr('name', $(this).attr('name').replace( number, new_number ) );
+			}//end if
+		});
+
+		// assign a unique id to this widget:
+		highest = 0;
+		$('.widget').each(function() {
+			var match = this.id.match( /^widget-(\d+)/ );
+
+			if ( match ) {
+				var widget_id = parseInt( match[1], 10 );
+
+				highest = widget_id > highest ? widget_id : highest;
+			}//end if
+		});
+
+		var new_id = highest + 1;
+
+		// Figure out the value of add_new from the source widget:
+		var add = $('#widget-list .id_base[value="' + id_base + '"]').siblings('.add_new').val();
+		$new[0].id = 'widget-' + new_id + '_' + id_base + '-' + new_number;
+		$new.find('input.widget-id').val( id_base + '-' + new_number );
+		$new.find('input.widget_number').val( new_number );
+		$original.after( $new );
+
+		// Not exactly sure what multi_number is used for.
+		$new.find('.multi_number').val( new_number );
+
+		wpWidgets.save($new, 0, 0, 1);
+	};
+})( jQuery );
+
+jQuery( function( $ ) {
+	go_copylayout.init();
+});


### PR DESCRIPTION
Bringing up a new site from scratch sucks. Especially when there are a lot of post loop widgets that you need to configure.  I found a WP plugin that does widget cloning.  I modified it to fit our standards and be a little bit more efficient and added it to go-copylayout.
